### PR TITLE
Collection Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ As these citation information are often closely bound to the Collection level an
 it is recommended adding the fields to the corresponding Collection.
 
 - Examples:
-  - [Item](examples/item.json): Shows the usage of the extension in a STAC Item
-  - [Collection](examples/collection.json): Shows the usage of the extension in a STAC Collection
+  - [Item](examples/item.json): The extension in a STAC Item
+  - [Collection](examples/collection.json): The extension in a STAC Collection
+  - [Collection (Assets)](examples/collection-assets.json): The extension in a STAC Collection with assets
+  - [Collection (Item Asset Definition)](examples/collection-item-assets.json): The extension in a STAC Collection in Item Asset Defintions
+  - [Collection (Summaries)](examples/collection-summaries.json): The extension in a STAC Collection in Summaries
 - [JSON Schema](json-schema/schema.json)
 - [Changelog](./CHANGELOG.md)
 

--- a/examples/collection-assets.json
+++ b/examples/collection-assets.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],

--- a/examples/collection-assets.json
+++ b/examples/collection-assets.json
@@ -1,0 +1,62 @@
+{
+  "stac_version": "1.0.0-rc.1",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
+  ],
+  "id": "MERRAclim",
+  "title": "MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",
+  "description": "Species Distribution Models (SDMs) combine information on the geographic occurrence of species with environmental layers to estimate distributional ranges and have been extensively implemented to answer a wide array of applied ecological questions. Unfortunately, most global datasets available to parameterize SDMs consist of spatially interpolated climate surfaces obtained from ground weather station data and have omitted the Antarctic continent, a landmass covering c. 20% of the Southern Hemisphere and increasingly showing biological effects of global change. Here we introduce MERRAclim, a global set of satellite-based bioclimatic variables including Antarctica for the first time. MERRAclim consists of three datasets of 19 bioclimatic variables that have been built for each of the last three decades (1980s, 1990s and 2000s) using hourly data of 2 m temperature and specific humidity. We provide MERRAclim at three spatial resolutions (10 arc-minutes, 5 arc-minutes and 2.5 arc-minutes). These reanalysed data are comparable to widely used datasets based on ground station interpolations, but allow extending their geographical reach and SDM building in previously uncovered regions of the globe.",
+  "type": "Collection",
+  "keywords": [
+    "bioclimatic",
+    "MERRAclim",
+    "macroecology",
+    "biogeography"
+  ],
+  "license": "CC0-1.0",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180,
+          -90,
+          180,
+          90
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "1980-01-01T00:00:00Z",
+          "2009-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "assets": {
+    "test": {
+      "href": "example.xml",
+      "type": "application/xml",
+      "sci:doi": "10.5061/dryad.s2v81.2"
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/collection.json"
+    },
+    {
+      "rel": "item",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/item.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/collection.json"
+    },
+    {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5061/dryad.s2v81.2"
+    }
+  ]
+}

--- a/examples/collection-item-assets.json
+++ b/examples/collection-item-assets.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],

--- a/examples/collection-item-assets.json
+++ b/examples/collection-item-assets.json
@@ -1,0 +1,62 @@
+{
+  "stac_version": "1.0.0-rc.1",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
+  ],
+  "id": "MERRAclim",
+  "title": "MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",
+  "description": "Species Distribution Models (SDMs) combine information on the geographic occurrence of species with environmental layers to estimate distributional ranges and have been extensively implemented to answer a wide array of applied ecological questions. Unfortunately, most global datasets available to parameterize SDMs consist of spatially interpolated climate surfaces obtained from ground weather station data and have omitted the Antarctic continent, a landmass covering c. 20% of the Southern Hemisphere and increasingly showing biological effects of global change. Here we introduce MERRAclim, a global set of satellite-based bioclimatic variables including Antarctica for the first time. MERRAclim consists of three datasets of 19 bioclimatic variables that have been built for each of the last three decades (1980s, 1990s and 2000s) using hourly data of 2 m temperature and specific humidity. We provide MERRAclim at three spatial resolutions (10 arc-minutes, 5 arc-minutes and 2.5 arc-minutes). These reanalysed data are comparable to widely used datasets based on ground station interpolations, but allow extending their geographical reach and SDM building in previously uncovered regions of the globe.",
+  "type": "Collection",
+  "keywords": [
+    "bioclimatic",
+    "MERRAclim",
+    "macroecology",
+    "biogeography"
+  ],
+  "license": "CC0-1.0",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180,
+          -90,
+          180,
+          90
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "1980-01-01T00:00:00Z",
+          "2009-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "item_assets": {
+    "primary": {
+      "type": "application/zip",
+      "title": "MERRAclim. 2_5m_min_80s",
+      "sci:doi": "10.5061/dryad.s2v81.2"
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/collection.json"
+    },
+    {
+      "rel": "item",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/item.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/collection.json"
+    },
+    {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5061/dryad.s2v81.2"
+    }
+  ]
+}

--- a/examples/collection-summaries.json
+++ b/examples/collection-summaries.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],

--- a/examples/collection-summaries.json
+++ b/examples/collection-summaries.json
@@ -1,0 +1,70 @@
+{
+  "stac_version": "1.0.0-rc.1",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
+  ],
+  "id": "MERRAclim",
+  "title": "MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",
+  "description": "Species Distribution Models (SDMs) combine information on the geographic occurrence of species with environmental layers to estimate distributional ranges and have been extensively implemented to answer a wide array of applied ecological questions. Unfortunately, most global datasets available to parameterize SDMs consist of spatially interpolated climate surfaces obtained from ground weather station data and have omitted the Antarctic continent, a landmass covering c. 20% of the Southern Hemisphere and increasingly showing biological effects of global change. Here we introduce MERRAclim, a global set of satellite-based bioclimatic variables including Antarctica for the first time. MERRAclim consists of three datasets of 19 bioclimatic variables that have been built for each of the last three decades (1980s, 1990s and 2000s) using hourly data of 2 m temperature and specific humidity. We provide MERRAclim at three spatial resolutions (10 arc-minutes, 5 arc-minutes and 2.5 arc-minutes). These reanalysed data are comparable to widely used datasets based on ground station interpolations, but allow extending their geographical reach and SDM building in previously uncovered regions of the globe.",
+  "type": "Collection",
+  "keywords": [
+    "bioclimatic",
+    "MERRAclim",
+    "macroecology",
+    "biogeography"
+  ],
+  "license": "CC0-1.0",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180,
+          -90,
+          180,
+          90
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "1980-01-01T00:00:00Z",
+          "2009-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "summaries": {
+    "sci:doi": [
+      "10.5061/dryad.s2v81.2/27.2"
+    ],
+    "sci:publications": [
+      {
+        "doi": "10.5061/dryad.s2v81.2",
+        "citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) Data from: MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Dryad Digital Repository."
+      },
+      {
+        "doi": "10.1038/sdata.2017.78",
+        "citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Scientific Data 4: 170078."
+      }
+    ]
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/collection.json"
+    },
+    {
+      "rel": "item",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/item.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/collection.json"
+    },
+    {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5061/dryad.s2v81.2"
+    }
+  ]
+}

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],

--- a/examples/item.json
+++ b/examples/item.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -2,11 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://stac-extensions.github.io/scientific/v1.0.0/schema.json#",
   "title": "Scientific Citation Extension",
-  "description": "STAC Scientific Citation Extension for STAC Items and STAC Collections.",
+  "description": "Scientific Citation Extension for STAC Items and STAC Collections.",
   "oneOf": [
     {
       "$comment": "This is the schema for STAC Items.",
       "allOf": [
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
         {
           "type": "object",
           "required": [
@@ -30,29 +33,32 @@
             },
             "assets": {
               "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
+              "not": {
+                "additionalProperties": {
+                  "not": {
+                    "$ref": "#/definitions/fields"
+                  }
+                }
               }
             }
           }
-        },
-        {
-          "$ref": "#/definitions/stac_extensions"
         }
       ]
     },
     {
       "$comment": "This is the schema for STAC Collections.",
       "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "const": "Collection"
-        }
-      },
       "allOf": [
+        {
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            }
+          }
+        },
         {
           "$ref": "#/definitions/stac_extensions"
         }
@@ -77,8 +83,19 @@
           "properties": {
             "assets": {
               "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
+              "not": {
+                "additionalProperties": {
+                  "not": {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/requirements"
+                      },
+                      {
+                        "$ref": "#/definitions/fields"
+                      }
+                    ]
+                  }
+                }
               }
             }
           }
@@ -91,20 +108,23 @@
           "properties": {
             "item_assets": {
               "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
+              "not": {
+                "additionalProperties": {
+                  "not": {
+                    "$ref": "#/definitions/fields"
+                  }
+                }
               }
             }
           }
         },
         {
-          "$comment": "This is the schema for the fields in Summaries.",
+          "$comment": "This is the schema for the fields in Summaries. by default, only checks the existance of the properties, but not the schema of the summaries.",
           "required": [
             "summaries"
           ],
           "properties": {
             "summaries": {
-              "type": "object",
               "$ref": "#/definitions/requirements"
             }
           }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -43,22 +43,52 @@
     },
     {
       "$comment": "This is the schema for STAC Collections.",
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "Collection"
+        }
+      },
       "allOf": [
         {
-          "type": "object",
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ],
+      "anyOf": [
+        {
+          "$comment": "This is the schema for the top-level fields in a Collection.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/requirements"
+            },
+            {
+              "$ref": "#/definitions/fields"
+            }
+          ]
+        },
+        {
+          "$comment": "This is the schema for the fields in Collection Assets.",
           "required": [
-            "type"
+            "assets"
           ],
           "properties": {
-            "type": {
-              "const": "Collection"
-            },
             "assets": {
               "type": "object",
               "additionalProperties": {
                 "$ref": "#/definitions/fields"
               }
-            },
+            }
+          }
+        },
+        {
+          "$comment": "This is the schema for the fields in Item Asset Definitions.",
+          "required": [
+            "item_assets"
+          ],
+          "properties": {
             "item_assets": {
               "type": "object",
               "additionalProperties": {
@@ -68,13 +98,16 @@
           }
         },
         {
-          "$ref": "#/definitions/stac_extensions"
-        },
-        {
-          "$ref": "#/definitions/requirements"
-        },
-        {
-          "$ref": "#/definitions/fields"
+          "$comment": "This is the schema for the fields in Summaries.",
+          "required": [
+            "summaries"
+          ],
+          "properties": {
+            "summaries": {
+              "type": "object",
+              "$ref": "#/definitions/requirements"
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
The schema for collections has an issue that comes up once you don't use sci: fields top-level in collections. This is an attempt to fix this issue.

This likely needs an alignment for all extensions and a change in the template.

This PR needs to be released as 1.0.1 for https://github.com/radiantearth/stac-spec/pull/1093 to work.

Haven't had the time yet to check in detail whether all my changes work properly, but added more examples to test against.
Issue will always be that we don't have https://github.com/json-schema-org/json-schema-spec/issues/1077 yet, so validation in Collections will be not very strict/reliable anyway.