### PR TITLE
Initial additions of orcid and ror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- sci:rors and sci:orcids to the item properties and collection fields. Fixes [#10](https://github.com/stac-extensions/scientific/issues/10)
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ For Items, the fields are placed in the `properties`. For Collections, the field
 | sci:doi          | string               | The DOI of the data, e.g. `10.1000/xyz123`. This MUST NOT be a DOIs link. For all DOI names respective DOI links SHOULD be added to the links section (see chapter "Relation types"). |
 | sci:citation     | string               | The recommended human-readable reference (citation) to be used by publications citing the data. No specific citation style is suggested, but the citation should contain all information required to find the publication distinctively. |
 | sci:publications | [[Publication Object](#publication-object)] | List of relevant publications referencing and describing the data. |
+| sci:orcids        | \[string]            | An array of Open Researcher Contribution IDs ([ORCID](https://orcid.org)) associated with this product. For all ORCIDs a link SHOULD be added to the links section.     |
+| sci:ror s         | \[string]            | An array of Research Organization Record ([ROR](https://ror.org)) entity name or unique identifier. For all ROR(s) names and identifiers a link SHOULD be added to the links section. |
 
 *At least one of the fields must be specified.*
 
@@ -69,6 +71,7 @@ The following types should be used as applicable `rel` types in the
 
 | Type    | Description |
 | ------- | ----------- |
+| author | An ORCID link SHOULD be added to the links section for the author(s) referenced by the `sci:orcids` property with the `rel` type `author`. (see [rel type author](https://html.spec.whatwg.org/multipage/links.html#link-type-author)) |
 | cite-as | A DOI link SHOULD be added to the links section for the publication referenced by the `sci:doi` property with the `rel` type `cite-as` (see the [RFC 8574](https://tools.ietf.org/html/rfc8574)). |
 
 ## Contributing

--- a/examples/collection-summaries.json
+++ b/examples/collection-summaries.json
@@ -47,7 +47,9 @@
         "doi": "10.1038/sdata.2017.78",
         "citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Scientific Data 4: 170078."
       }
-    ]
+    ],
+    "sci:orcids": ["0000-0001-5115-0146","0000-0002-2232-428X"],
+    "sci:rors": ["00g0p6g84"]
   },
   "links": [
     {

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -36,6 +36,8 @@
   },
   "sci:doi": "10.5061/dryad.s2v81.2",
   "sci:citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) Data from: MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Dryad Digital Repository.",
+  "sci:orcids": ["0000-0001-5115-0146","0000-0002-2232-428X"],
+  "sci:rors": ["00g0p6g84"],
   "sci:publications": [
     {
       "doi": "10.1038/sdata.2017.78",
@@ -58,6 +60,18 @@
     {
       "rel": "cite-as",
       "href": "https://doi.org/10.5061/dryad.s2v81.2"
+    },
+    {
+      "rel": "related",
+      "href": "https://orcid.org/0000-0001-5115-0146"
+    },
+    {
+      "rel": "related",
+      "href": "https://orcid.org/0000-0002-2232-428X"
+    },
+    {
+      "rel": "related",
+      "href": "https://ror.org/00g0p6g84"
     }
   ]
 }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -172,6 +172,22 @@
           "type": "string", 
           "title": "Proposed Data Citation"
         },
+        "sci:orcids": {
+          "type": "array", 
+          "title": "ORCID(s) for data producers.",
+          "minItems": 1,
+          "items": {
+            "type":"string"
+          }
+        },
+        "sci:rors": {
+          "type": "array", 
+          "title": "RoR for data producer institutions.",
+          "minItems": 1,
+          "items": {
+            "type":"string"
+          }
+        },
         "sci:publications": {
           "type": "array",
           "title": "Publications",


### PR DESCRIPTION
Adds ORCID and RoR identifiers.

A few items for discussion:

- I am not happy with the rel type on the links. What is an appropriate rel type? cite-as does not make sense here, because they are not citable. These are identifiers for the authors and their institutions.
- The tests on the updated collection and summaries collection will not pass while the stac-extensions entry is v1.0.0 and these changes are in an unreleased branch. What is the canonical way to make this update and have the CI test?